### PR TITLE
Fix production API URL configuration

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,7 +31,8 @@ function App() {
 
   const sendMessage = async (text: string): Promise<ApiResponse> => {
     try {
-      const response = await fetch(import.meta.env.VITE_API_URL, {
+      const apiUrl = import.meta.env.VITE_API_URL || 'https://api.iapivara.com.br';
+      const response = await fetch(apiUrl, {
         method: 'POST',
         headers: { 
           'Content-Type': 'application/json',


### PR DESCRIPTION
- Add fallback URL in App.tsx to handle cases where VITE_API_URL is undefined
- Prevents requests to 'undefined' URL causing 405 Method Not Allowed errors
- Ensures API calls go to https://api.iapivara.com.br in production
- Tested locally with successful API responses

For production deployment, set VITE_API_URL=https://api.iapivara.com.br during build